### PR TITLE
[#42] Add GitHub issue & pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_request.yml
+++ b/.github/ISSUE_TEMPLATE/bug_request.yml
@@ -1,0 +1,58 @@
+name: 🐞 Bug Request
+description: You found a bug in this project
+title: "🐞 Fix: "
+labels: ['bug']
+projects: ['idembele70/10']
+assignees:
+  - idembele70
+body:
+
+  - type: markdown
+    attributes: 
+      value: |
+        **Thanks for taking the time to explain this bug!**
+
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for the bug you encountered.
+      options:
+        - label: I have searched existing issues
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Current Behavior
+      description: A concise description of what you're experiencing.
+    validations:
+      required: false
+  
+  - type: textarea
+    attributes: 
+      label: Expected Behavior
+      description: A concise description of what you expected to happen.
+    validations:
+      required: false
+  
+  - type: textarea
+    attributes:
+      label: Steps To Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. In this environment...
+        1. With this config
+        1. Run '...'
+        1. See error...
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Anything else?
+      description: |
+        Links? References? Anything that will give us more context about the issue you are encountering!
+
+        Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
+    validations:
+      required: false
+        

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,43 @@
+name: 🚀 Feature Request
+description: You have a specific idea to suggest for this project 💡
+title: "💡 Feature: "
+labels: ['enhancement']
+projects: ['idembele70/10']
+assignees:
+  - idembele70
+body:
+
+  - type: markdown
+    attributes:
+      value: |
+        **Thanks for taking the time to suggest a new feature!**
+
+        Before you open an issue, please check if a similar issue already exists or has been closed before
+  
+  - type: textarea
+    attributes:
+      label: Actual Behavior
+      description: Tell us what happened instead.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: Tell us what should happen.
+    validations:
+      required: true
+  
+  - type: textarea
+    attributes:
+      label: Describe the alternatives you've considered
+      description: A clear and concise description of any alternative solutions or features you've considered.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Acceptance Criteria
+      description: A list of the whole acceptance criteria.
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+What does this implement/fix? Explain your changes.
+---------------------------------------------------
+<!-- Describe the changes in the PR and their purpose. For example: -->
+<!-- Added new test cases for user login feature using Playwright -->
+<!-- Fixed a bug in the shopping cart tests -->
+
+Does this close any currently open issues?
+------------------------------------------
+<!-- List any issues that this PR closes. For example: -->
+
+Any other comments?
+-------------------
+<!-- Any other information or context you think is relevant to the reviewers -->
+
+Changes to Core Features:
+-------------------------
+- [ ] Have you done X?
+- [ ] Have you done Y?
+
+I'm not a dummy, so I've checked these:
+--------------------------------------
+- [ ] I've made changes requested by Copilot.
+- [ ] I made a **self-review**.


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
AddS default GitHub templates for:
- Features request issues
- Bug report issues
- Pull requests

Does this close any currently open issues?
------------------------------------------
Closes #15 

Any other comments?
-------------------
<!-- Any other information or context you think is relevant to the reviewers -->

Changes to Core Features:
-------------------------
- [x] Feature request issue template added
- [x] Bug report issue template added
- [x] Pull request template added

I'm not a dummy, so I've checked these:
--------------------------------------
- [ ] I've made changes requested by Copilot.
- [ ] I made a **self-review**.